### PR TITLE
feat: Disallow laby completely

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,7 @@ A simple plugin to utilize LabyMod's server API without coding knowledge.
 ## General info
 
 ### Features
+- Disallow LabyMod completely by kicking players as soon as they join with LabyMod
 - Custom banner above the tablist
 - An economy display (cash & bank) using [Vault](https://www.spigotmc.org/resources/vault.34315/)
 - Country flags beside your name in the tablist
@@ -31,8 +32,8 @@ A simple plugin to utilize LabyMod's server API without coding knowledge.
 - `/labyutils` - Reloads the config.
 
 ### Permissions
-- `labyutils.bypass.*` - Ignores all recommended, required, or disallowed addons
-- `labyutils.bypass.<namespace>` - Ignores a specific recommended, required, or disallowed addon
+- `labyutils.bypass.addon.*` - Ignores all recommended, required, or disallowed addons
+- `labyutils.bypass.addon.<namespace>` - Ignores a specific recommended, required, or disallowed addon
 - `labyutils.info` - Grants base access to `/labyinfo`
 - `labyutils.info.subtitle` - See player subtitles in `/labyutils`
 - `labyutils.info.economy` - See economy balances in `/labyutils`

--- a/src/main/java/com/rappytv/labyutils/bukkit/BukkitConfigManager.java
+++ b/src/main/java/com/rappytv/labyutils/bukkit/BukkitConfigManager.java
@@ -24,11 +24,11 @@ public class BukkitConfigManager implements IConfigManager<ConfigurationSection>
     }
 
     public boolean isLabyModDisallowed() {
-        return config.getBoolean("labymod.disallow.enabled");
+        return config.getBoolean("disallow.enabled");
     }
 
     public String getDisallowedKickMessage() {
-        return config.getString("labymod.force.kickMessage", defaultDisallowedKickMessage);
+        return config.getString("disallow.kickMessage", defaultDisallowedKickMessage);
     }
 
     public boolean isWelcomeLogEnabled() {

--- a/src/main/java/com/rappytv/labyutils/bukkit/BukkitConfigManager.java
+++ b/src/main/java/com/rappytv/labyutils/bukkit/BukkitConfigManager.java
@@ -23,6 +23,14 @@ public class BukkitConfigManager implements IConfigManager<ConfigurationSection>
         return config.getString("prefix", defaultPrefix);
     }
 
+    public boolean isLabyModDisallowed() {
+        return config.getBoolean("labymod.disallow.enabled");
+    }
+
+    public String getDisallowedKickMessage() {
+        return config.getString("labymod.force.kickMessage", defaultDisallowedKickMessage);
+    }
+
     public boolean isWelcomeLogEnabled() {
         return config.getBoolean("welcome.log");
     }
@@ -84,7 +92,7 @@ public class BukkitConfigManager implements IConfigManager<ConfigurationSection>
     }
 
     public String getAddonKickMessage() {
-        return config.getString("addons.kickMessage", defaultKickMessage);
+        return config.getString("addons.kickMessage", defaultAddonKickMessage);
     }
 
     public boolean arePermissionsEnabled() {

--- a/src/main/java/com/rappytv/labyutils/bukkit/listeners/PlayerListener.java
+++ b/src/main/java/com/rappytv/labyutils/bukkit/listeners/PlayerListener.java
@@ -150,6 +150,42 @@ public class PlayerListener implements Listener, IPlayerListener<LabyModPlayerJo
         if(!entries.isEmpty()) player.sendInteractionMenuEntries(entries);
     }
 
+    public void managePermissions(LabyModPlayer player) {
+        if(!plugin.getConfigManager().arePermissionsEnabled()) return;
+        // TODO: Find error source
+        List<Permission.StatedPermission> permissions = new ArrayList<>();
+        ConfigurationSection section = plugin
+                .getConfigManager()
+                .getPermissions();
+
+        if(section == null) return;
+
+        for(String key : section.getKeys(false)) {
+            boolean hasPermission = player.getPlayer().hasPermission("labyutils.permissions.*")
+                    || player.getPlayer().hasPermission("labyutils.permissions." + section.getString(key));
+            permissions.add(hasPermission ? Permission.of(key).allow() : Permission.of(key).deny());
+        }
+
+        player.sendPermissions(permissions);
+    }
+
+    public void setRPC(LabyModPlayer player) {
+        if(!plugin.getConfigManager().isRpcEnabled()) return;
+        String text = plugin.getConfigManager().getRpcText();
+        boolean showTime = plugin.getConfigManager().showRpcJoinTime();
+
+        if(text == null) return;
+        if(plugin.isUsingPapi()) {
+            text = PlaceholderAPI.setPlaceholders(player.getPlayer(), text);
+        }
+
+        DiscordRPC rpc = showTime
+                ? DiscordRPC.createWithStart(text, System.currentTimeMillis())
+                : DiscordRPC.create(text);
+
+        player.sendDiscordRPC(rpc);
+    }
+
     public void manageAddons(LabyModPlayer player) {
         if(!plugin.getConfigManager().isAddonManagementEnabled()) return;
         List<RecommendedAddon> recommendedAddons = new ArrayList<>();
@@ -192,41 +228,5 @@ public class PlayerListener implements Listener, IPlayerListener<LabyModPlayerJo
         if(!disabledAddons.isEmpty()) {
             player.disableAddons(disabledAddons);
         }
-    }
-
-    public void managePermissions(LabyModPlayer player) {
-        if(!plugin.getConfigManager().arePermissionsEnabled()) return;
-        // TODO: Find error source
-        List<Permission.StatedPermission> permissions = new ArrayList<>();
-        ConfigurationSection section = plugin
-                .getConfigManager()
-                .getPermissions();
-
-        if(section == null) return;
-
-        for(String key : section.getKeys(false)) {
-            boolean hasPermission = player.getPlayer().hasPermission("labyutils.permissions.*")
-                    || player.getPlayer().hasPermission("labyutils.permissions." + section.getString(key));
-            permissions.add(hasPermission ? Permission.of(key).allow() : Permission.of(key).deny());
-        }
-
-        player.sendPermissions(permissions);
-    }
-
-    public void setRPC(LabyModPlayer player) {
-        if(!plugin.getConfigManager().isRpcEnabled()) return;
-        String text = plugin.getConfigManager().getRpcText();
-        boolean showTime = plugin.getConfigManager().showRpcJoinTime();
-
-        if(text == null) return;
-        if(plugin.isUsingPapi()) {
-            text = PlaceholderAPI.setPlaceholders(player.getPlayer(), text);
-        }
-
-        DiscordRPC rpc = showTime
-                ? DiscordRPC.createWithStart(text, System.currentTimeMillis())
-                : DiscordRPC.create(text);
-
-        player.sendDiscordRPC(rpc);
     }
 }

--- a/src/main/java/com/rappytv/labyutils/bukkit/listeners/PlayerListener.java
+++ b/src/main/java/com/rappytv/labyutils/bukkit/listeners/PlayerListener.java
@@ -32,6 +32,8 @@ public class PlayerListener implements Listener, IPlayerListener<LabyModPlayerJo
     public void onPlayerJoin(LabyModPlayerJoinEvent event) {
         LabyModPlayer labyPlayer = event.labyModPlayer();
 
+        if(disallowLabyMod(labyPlayer)) return;
+
         logJoin(labyPlayer);
         sendWelcomer(labyPlayer);
         setBanner(labyPlayer);
@@ -47,6 +49,15 @@ public class PlayerListener implements Listener, IPlayerListener<LabyModPlayerJo
     public void onQuit(PlayerQuitEvent event) {
         EconomyBalanceUpdateEvent.cashBalances.remove(event.getPlayer().getUniqueId());
         EconomyBalanceUpdateEvent.bankBalances.remove(event.getPlayer().getUniqueId());
+    }
+
+    @Override
+    public boolean disallowLabyMod(LabyModPlayer player) {
+        if(plugin.getConfigManager().isLabyModDisallowed()) {
+            player.getPlayer().kickPlayer(plugin.getConfigManager().getDisallowedKickMessage());
+            return true;
+        }
+        return false;
     }
 
     public void logJoin(LabyModPlayer player) {

--- a/src/main/java/com/rappytv/labyutils/bukkit/listeners/PlayerListener.java
+++ b/src/main/java/com/rappytv/labyutils/bukkit/listeners/PlayerListener.java
@@ -53,7 +53,7 @@ public class PlayerListener implements Listener, IPlayerListener<LabyModPlayerJo
 
     @Override
     public boolean disallowLabyMod(LabyModPlayer player) {
-        if(plugin.getConfigManager().isLabyModDisallowed()) {
+        if(plugin.getConfigManager().isLabyModDisallowed() && !player.getPlayer().hasPermission("labyutils.bypass.labymod")) {
             player.getPlayer().kickPlayer(plugin.getConfigManager().getDisallowedKickMessage());
             return true;
         }
@@ -198,8 +198,8 @@ public class PlayerListener implements Listener, IPlayerListener<LabyModPlayerJo
         if(section == null) return;
 
         for(String key : section.getKeys(false)) {
-            boolean canBypass = player.getPlayer().hasPermission("labyutils.bypass.*")
-                    || player.getPlayer().hasPermission("labyutils.bypass." + key);
+            boolean canBypass = player.getPlayer().hasPermission("labyutils.bypass.addon.*")
+                    || player.getPlayer().hasPermission("labyutils.bypass.addon." + key);
             if(canBypass) continue;
             switch (section.getString(key, "none").toLowerCase()) {
                 case "recommend":

--- a/src/main/java/com/rappytv/labyutils/bungee/BungeeConfigManager.java
+++ b/src/main/java/com/rappytv/labyutils/bungee/BungeeConfigManager.java
@@ -13,7 +13,6 @@ public class BungeeConfigManager implements IConfigManager<Configuration> {
         this.config = pluginConfig.get();
     }
 
-    @Override
     public void reloadConfig() {
         pluginConfig.reload();
         config = pluginConfig.get();
@@ -21,6 +20,14 @@ public class BungeeConfigManager implements IConfigManager<Configuration> {
 
     public String getPrefix() {
         return config.getString("prefix", defaultPrefix);
+    }
+
+    public boolean isLabyModDisallowed() {
+        return config.getBoolean("labymod.disallow.enabled");
+    }
+
+    public String getDisallowedKickMessage() {
+        return config.getString("labymod.force.kickMessage", defaultDisallowedKickMessage);
     }
 
     public boolean isWelcomeLogEnabled() {
@@ -84,7 +91,7 @@ public class BungeeConfigManager implements IConfigManager<Configuration> {
     }
 
     public String getAddonKickMessage() {
-        return config.getString("addons.kickMessage", defaultKickMessage);
+        return config.getString("addons.kickMessage", defaultAddonKickMessage);
     }
 
     public boolean arePermissionsEnabled() {

--- a/src/main/java/com/rappytv/labyutils/bungee/BungeeConfigManager.java
+++ b/src/main/java/com/rappytv/labyutils/bungee/BungeeConfigManager.java
@@ -23,11 +23,11 @@ public class BungeeConfigManager implements IConfigManager<Configuration> {
     }
 
     public boolean isLabyModDisallowed() {
-        return config.getBoolean("labymod.disallow.enabled");
+        return config.getBoolean("disallow.enabled");
     }
 
     public String getDisallowedKickMessage() {
-        return config.getString("labymod.force.kickMessage", defaultDisallowedKickMessage);
+        return config.getString("disallow.kickMessage", defaultDisallowedKickMessage);
     }
 
     public boolean isWelcomeLogEnabled() {

--- a/src/main/java/com/rappytv/labyutils/bungee/listener/PlayerListener.java
+++ b/src/main/java/com/rappytv/labyutils/bungee/listener/PlayerListener.java
@@ -44,7 +44,7 @@ public class PlayerListener implements Listener, IPlayerListener<LabyModPlayerJo
 
     @Override
     public boolean disallowLabyMod(LabyModPlayer player) {
-        if(plugin.getConfigManager().isLabyModDisallowed()) {
+        if(plugin.getConfigManager().isLabyModDisallowed() && !player.getPlayer().hasPermission("labyutils.bypass.labymod")) {
             player.getPlayer().disconnect(
                     TextComponent.fromLegacyText(
                             plugin
@@ -195,8 +195,8 @@ public class PlayerListener implements Listener, IPlayerListener<LabyModPlayerJo
         if(section == null) return;
 
         for(String key : section.getKeys()) {
-            boolean canBypass = player.getPlayer().hasPermission("labyutils.bypass.*")
-                    || player.getPlayer().hasPermission("labyutils.bypass." + key);
+            boolean canBypass = player.getPlayer().hasPermission("labyutils.bypass.addon.*")
+                    || player.getPlayer().hasPermission("labyutils.bypass.addon." + key);
             if(canBypass) continue;
             switch (section.getString(key, "none").toLowerCase()) {
                 case "recommend":

--- a/src/main/java/com/rappytv/labyutils/bungee/listener/PlayerListener.java
+++ b/src/main/java/com/rappytv/labyutils/bungee/listener/PlayerListener.java
@@ -29,6 +29,8 @@ public class PlayerListener implements Listener, IPlayerListener<LabyModPlayerJo
     public void onPlayerJoin(LabyModPlayerJoinEvent event) {
         LabyModPlayer labyPlayer = event.labyModPlayer();
 
+        if(disallowLabyMod(labyPlayer)) return;
+
         logJoin(labyPlayer);
         sendWelcomer(labyPlayer);
         setBanner(labyPlayer);
@@ -38,6 +40,21 @@ public class PlayerListener implements Listener, IPlayerListener<LabyModPlayerJo
         manageAddons(labyPlayer);
         managePermissions(labyPlayer);
         setRPC(labyPlayer);
+    }
+
+    @Override
+    public boolean disallowLabyMod(LabyModPlayer player) {
+        if(plugin.getConfigManager().isLabyModDisallowed()) {
+            player.getPlayer().disconnect(
+                    TextComponent.fromLegacyText(
+                            plugin
+                                    .getConfigManager()
+                                    .getDisallowedKickMessage()
+                    )
+            );
+            return true;
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/com/rappytv/labyutils/bungee/listener/PlayerListener.java
+++ b/src/main/java/com/rappytv/labyutils/bungee/listener/PlayerListener.java
@@ -37,9 +37,9 @@ public class PlayerListener implements Listener, IPlayerListener<LabyModPlayerJo
         setFlag(labyPlayer);
         setSubtitle(labyPlayer);
         setInteractionBullets(labyPlayer);
-        manageAddons(labyPlayer);
         managePermissions(labyPlayer);
         setRPC(labyPlayer);
+        manageAddons(labyPlayer);
     }
 
     @Override
@@ -148,6 +148,41 @@ public class PlayerListener implements Listener, IPlayerListener<LabyModPlayerJo
     }
 
     @Override
+    public void managePermissions(LabyModPlayer player) {
+        if(!plugin.getConfigManager().arePermissionsEnabled()) return;
+        // TODO: Find error source
+        List<Permission.StatedPermission> permissions = new ArrayList<>();
+        Configuration section = plugin
+                .getConfigManager()
+                .getPermissions();
+
+        if(section == null) return;
+
+        for(String key : section.getKeys()) {
+            boolean hasPermission = player.getPlayer().hasPermission("labyutils.permissions.*")
+                    || player.getPlayer().hasPermission("labyutils.permissions." + section.getString(key));
+            permissions.add(hasPermission ? Permission.of(key).allow() : Permission.of(key).deny());
+        }
+
+        player.sendPermissions(permissions);
+    }
+
+    @Override
+    public void setRPC(LabyModPlayer player) {
+        if(!plugin.getConfigManager().isRpcEnabled()) return;
+        String text = plugin.getConfigManager().getRpcText();
+        boolean showTime = plugin.getConfigManager().showRpcJoinTime();
+
+        if(text == null) return;
+
+        DiscordRPC rpc = showTime
+                ? DiscordRPC.createWithStart(text, System.currentTimeMillis())
+                : DiscordRPC.create(text);
+
+        player.sendDiscordRPC(rpc);
+    }
+
+    @Override
     public void manageAddons(LabyModPlayer player) {
         if(!plugin.getConfigManager().isAddonManagementEnabled()) return;
         List<RecommendedAddon> recommendedAddons = new ArrayList<>();
@@ -192,40 +227,5 @@ public class PlayerListener implements Listener, IPlayerListener<LabyModPlayerJo
         if(!disabledAddons.isEmpty()) {
             player.disableAddons(disabledAddons);
         }
-    }
-
-    @Override
-    public void managePermissions(LabyModPlayer player) {
-        if(!plugin.getConfigManager().arePermissionsEnabled()) return;
-        // TODO: Find error source
-        List<Permission.StatedPermission> permissions = new ArrayList<>();
-        Configuration section = plugin
-                .getConfigManager()
-                .getPermissions();
-
-        if(section == null) return;
-
-        for(String key : section.getKeys()) {
-            boolean hasPermission = player.getPlayer().hasPermission("labyutils.permissions.*")
-                    || player.getPlayer().hasPermission("labyutils.permissions." + section.getString(key));
-            permissions.add(hasPermission ? Permission.of(key).allow() : Permission.of(key).deny());
-        }
-
-        player.sendPermissions(permissions);
-    }
-
-    @Override
-    public void setRPC(LabyModPlayer player) {
-        if(!plugin.getConfigManager().isRpcEnabled()) return;
-        String text = plugin.getConfigManager().getRpcText();
-        boolean showTime = plugin.getConfigManager().showRpcJoinTime();
-
-        if(text == null) return;
-
-        DiscordRPC rpc = showTime
-                ? DiscordRPC.createWithStart(text, System.currentTimeMillis())
-                : DiscordRPC.create(text);
-
-        player.sendDiscordRPC(rpc);
     }
 }

--- a/src/main/java/com/rappytv/labyutils/common/IConfigManager.java
+++ b/src/main/java/com/rappytv/labyutils/common/IConfigManager.java
@@ -3,10 +3,13 @@ package com.rappytv.labyutils.common;
 public interface IConfigManager<T> {
 
     String defaultPrefix = "§8[§9LABY§8] ";
-    String defaultKickMessage = "§c§lKICKED!\n\n§bReason: §7Missing required addons: %s";
+    String defaultAddonKickMessage = "§c§lKICKED!\n\n§bReason: §7Missing required addons: %s";
+    String defaultDisallowedKickMessage = "§c§lKICKED!\n\n§bReason: §7You are not allowed to join this server using §9LabyMod§7!";
 
     void reloadConfig();
     String getPrefix();
+    boolean isLabyModDisallowed();
+    String getDisallowedKickMessage();
     boolean isWelcomeLogEnabled();
     boolean isWelcomeMessageEnabled();
     String getWelcomeMessage();

--- a/src/main/java/com/rappytv/labyutils/common/listeners/IPlayerListener.java
+++ b/src/main/java/com/rappytv/labyutils/common/listeners/IPlayerListener.java
@@ -4,6 +4,7 @@ import net.labymod.serverapi.server.common.model.player.AbstractServerLabyModPla
 
 public interface IPlayerListener<E, L extends AbstractServerLabyModPlayer<?, ?>> {
 
+    @SuppressWarnings("unused")
     void onPlayerJoin(E event);
 
     boolean disallowLabyMod(L player);

--- a/src/main/java/com/rappytv/labyutils/common/listeners/IPlayerListener.java
+++ b/src/main/java/com/rappytv/labyutils/common/listeners/IPlayerListener.java
@@ -6,6 +6,7 @@ public interface IPlayerListener<E, L extends AbstractServerLabyModPlayer<?, ?>>
 
     void onPlayerJoin(E event);
 
+    boolean disallowLabyMod(L player);
     void logJoin(L player);
     void sendWelcomer(L player);
     void setBanner(L player);

--- a/src/main/java/com/rappytv/labyutils/common/listeners/IPlayerListener.java
+++ b/src/main/java/com/rappytv/labyutils/common/listeners/IPlayerListener.java
@@ -13,7 +13,7 @@ public interface IPlayerListener<E, L extends AbstractServerLabyModPlayer<?, ?>>
     void setFlag(L player);
     void setSubtitle(L player);
     void setInteractionBullets(L player);
-    void manageAddons(L player);
     void managePermissions(L player);
     void setRPC(L player);
+    void manageAddons(L player);
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -13,6 +13,7 @@ prefix: '§8[§9LABY§8] '
 
 disallow:
   # Enable this to prevent players from joining with LabyMod.
+  # Players can bypass being kicked by having the 'labyutils.bypass.labymod' permission
   enabled: false
   kickMessage: |-
     §c§lKICKED!
@@ -105,7 +106,7 @@ addons:
     # - require - Recommends addon to player AND kicks player if they didn't download it
     # - disable - Disables addon completely
     #
-    # To add a bypass for an addon give the 'labyutils.bypass.<namespace>'
+    # To add a bypass for an addon give the 'labyutils.bypass.addon.<namespace>'
     # permission to a player or a group and the action will be prevented.
     someaddon: recommend
     someotheraddon: disable

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -11,6 +11,14 @@
 # Customize the plugin prefix for all messages sent by the plugin
 prefix: '§8[§9LABY§8] '
 
+disallow:
+  # Enable this to prevent players from joining with LabyMod.
+  enabled: false
+  kickMessage: |-
+    §c§lKICKED!
+    
+    §bReason: §7You are not allowed to join this server using §9LabyMod§7!
+
 welcome:
   # Enables a welcome message specifically for LabyMod players
   enabled: false

--- a/src/main/resources/config_bungee.yml
+++ b/src/main/resources/config_bungee.yml
@@ -11,6 +11,14 @@
 # Customize the plugin prefix for all messages sent by the plugin
 prefix: '§8[§9LABY§8] '
 
+disallow:
+  # Enable this to prevent players from joining with LabyMod
+  enabled: false
+  kickMessage: |-
+    §c§lKICKED!
+    
+    §bReason: §7You are not allowed to join this server using §9LabyMod§7!
+
 welcome:
   # Enables a welcome message specifically for LabyMod players
   enabled: false

--- a/src/main/resources/config_bungee.yml
+++ b/src/main/resources/config_bungee.yml
@@ -95,7 +95,7 @@ addons:
     # - require - Recommends addon to player AND kicks player if they didn't download it
     # - disable - Disables addon completely
     #
-    # To add a bypass for an addon give the 'labyutils.bypass.<namespace>'
+    # To add a bypass for an addon give the 'labyutils.bypass.addon.<namespace>'
     # permission to a player or a group and the action will be prevented.
     someaddon: recommend
     someotheraddon: disable

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -9,9 +9,12 @@ softdepend:
   - PlaceholderAPI
 
 permissions:
-  labyutils.bypass.*:
+  labyutils.bypass.addon.*:
     default: op
     description: Ignores any recommended, required, or disallowed addons
+  labyutils.bypass.labymod:
+    default: op
+    description: Lets the player join with LabyMod when it's disallowed
   labyutils.info:
     default: op
     description: Lets the player use /labyinfo


### PR DESCRIPTION
Forcing LabyMod is not possible unfortunately as it only sends an event for players who do join with LabyMod and it would be a very hacky solution to check 5 seconds after join if the player is using LabyMod.